### PR TITLE
Added JsonHelper class

### DIFF
--- a/AuthCode/AccessToken.cs
+++ b/AuthCode/AccessToken.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using EncompassREST.Exceptions;
 using EncompassREST.HelperClasses;
+using EncompassREST.Json;
 using Newtonsoft.Json;
 
 namespace EncompassREST
@@ -78,7 +79,7 @@ namespace EncompassREST
             var response = await _authClient.SendAsync(message);
             if (response.IsSuccessStatusCode)
             {
-                return JsonConvert.DeserializeObject<TokenValidateResponse>(await response.Content.ReadAsStringAsync());
+                return JsonHelper.FromJson<TokenValidateResponse>(await response.Content.ReadAsStringAsync());
             }
             else
             {
@@ -127,7 +128,7 @@ namespace EncompassREST
             if (response.IsSuccessStatusCode)
             {
                 var tokenData = await response.Content.ReadAsStringAsync();
-                var tr = JsonConvert.DeserializeObject<TokenResponse>(tokenData);
+                var tr = JsonHelper.FromJson<TokenResponse>(tokenData);
                 _token = tr;
                 return true;
             }

--- a/Data/1LoanExtensions.cs
+++ b/Data/1LoanExtensions.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using EncompassREST.Json;
 
 namespace EncompassREST.Data 
 {
@@ -19,7 +20,7 @@ namespace EncompassREST.Data
         public static async Task PopulateLoan(this Loan tLoan, string JsonData, Session Session)
         {
             //Loan l = await JsonConvert.DeserializeObjectAsync<Data.Loan>(JsonData);
-            await Task.Factory.StartNew(() => JsonConvert.PopulateObject(JsonData, tLoan));
+            await Task.Factory.StartNew(() => JsonHelper.Populate(JsonData, tLoan));
             tLoan._StartingData = JsonData;
             tLoan._Session = Session;
             return;

--- a/Documents.cs
+++ b/Documents.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using EncompassREST.Data;
 using EncompassREST.Exceptions;
+using EncompassREST.Json;
 using EncompassREST.LoanDocs;
 using Newtonsoft.Json;
 
@@ -31,7 +32,7 @@ namespace EncompassREST
             var response = await Session.RESTClient.SendAsync(message);
             if (response.IsSuccessStatusCode)
             {
-                return JsonConvert.DeserializeObject<List<Document>>(await response.Content.ReadAsStringAsync());
+                return JsonHelper.FromJson<List<Document>>(await response.Content.ReadAsStringAsync());
             }
             else
             {
@@ -45,7 +46,7 @@ namespace EncompassREST
             var response = await Session.RESTClient.SendAsync(message);
             if (response.IsSuccessStatusCode)
             {
-                return JsonConvert.DeserializeObject<Document>(await response.Content.ReadAsStringAsync());
+                return JsonHelper.FromJson<Document>(await response.Content.ReadAsStringAsync());
             }
             else
             {
@@ -59,7 +60,7 @@ namespace EncompassREST
             var response = await Session.RESTClient.SendAsync(message);
             if (response.IsSuccessStatusCode)
             {
-                return JsonConvert.DeserializeObject<List<Attachment>>(await response.Content.ReadAsStringAsync());
+                return JsonHelper.FromJson<List<Attachment>>(await response.Content.ReadAsStringAsync());
             }
             else
             {
@@ -79,7 +80,7 @@ namespace EncompassREST
 
             var message = new HttpRequestMessage(HttpMethod.Post, $"loans/{_loan.encompassId}/documents")
             {
-                Content = new StringContent(JsonConvert.SerializeObject(newDoc), Encoding.UTF32, "application/json")
+                Content = new StringContent(newDoc.ToJson(), Encoding.UTF32, "application/json")
             };
             var response = await Session.RESTClient.SendAsync(message);
             if (response.IsSuccessStatusCode)
@@ -100,7 +101,7 @@ namespace EncompassREST
 
             if (response.IsSuccessStatusCode)
             {
-                var mu = JsonConvert.DeserializeObject<MediaURL>(await response.Content.ReadAsStringAsync());
+                var mu = JsonHelper.FromJson<MediaURL>(await response.Content.ReadAsStringAsync());
                 return mu.mediaUrl;
             }
             else

--- a/EncompassREST.csproj
+++ b/EncompassREST.csproj
@@ -52,8 +52,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -272,7 +272,7 @@
     <Compile Include="Data\VerificationLog.cs" />
     <Compile Include="Exceptions\ExceptionClasses.cs" />
     <Compile Include="HelperClasses\HttpClientExtensions.cs" />
-    <Compile Include="JsonHelpers\JsonExtensions.cs" />
+    <Compile Include="Json\JsonHelper.cs" />
     <Compile Include="Loans.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="HelperClasses\RequestParameters.cs" />

--- a/Exceptions/ExceptionClasses.cs
+++ b/Exceptions/ExceptionClasses.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Web.Http;
+using EncompassREST.Json;
 
 namespace EncompassREST.Exceptions
 {
@@ -26,7 +27,7 @@ namespace EncompassREST.Exceptions
         public LoanLockedException(string message, HttpResponseMessage response) : base(message, response)
         {
             var value =  response.Content.ReadAsStringAsync().Result;
-            LoanLocked = JsonConvert.DeserializeObject<LoanLocked>(value);
+            LoanLocked = JsonHelper.FromJson<LoanLocked>(value);
         }
     }
 

--- a/Json/JsonHelper.cs
+++ b/Json/JsonHelper.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
-namespace EncompassREST.JsonHelpers
+namespace EncompassREST.Json
 {
-    public static class JsonExtensions
+    internal static class JsonHelper
     {
         public static List<JToken> FindTokens(this JToken containerToken, string name)
         {
@@ -33,5 +35,21 @@ namespace EncompassREST.JsonHelpers
                 }
             }
         }
+
+        public static JsonSerializerSettings Settings { get; } = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            Formatting = Formatting.None,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            }
+        };
+
+        public static string ToJson<T>(this T value) => JsonConvert.SerializeObject(value, typeof(T), Settings);
+
+        public static T FromJson<T>(string json) => JsonConvert.DeserializeObject<T>(json, Settings);
+
+        public static void Populate(string json, object value) => JsonConvert.PopulateObject(json, value, Settings);
     }
 }

--- a/Loans.cs
+++ b/Loans.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using EncompassREST.Data;
 using EncompassREST.Exceptions;
 using EncompassREST.HelperClasses;
+using EncompassREST.Json;
 using Newtonsoft.Json;
 
 namespace EncompassREST
@@ -350,7 +351,7 @@ namespace EncompassREST
             {
                 var content = await response.Content.ReadAsStringAsync();
                 var c = content.Replace(((char)65279).ToString(), "");
-                var data  = JsonConvert.DeserializeObject<IEnumerable<string>>(c);
+                var data = JsonHelper.FromJson<IEnumerable<string>>(c);
                 return data;
             }
             else

--- a/Pipeline.cs
+++ b/Pipeline.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using EncompassREST.Exceptions;
 using EncompassREST.HelperClasses;
+using EncompassREST.Json;
 using EncompassREST.PipelineModels;
 using Newtonsoft.Json;
 
@@ -44,7 +45,7 @@ namespace EncompassREST
             {
                 NullValueHandling = NullValueHandling.Ignore
             };
-            message.Content = new StringContent(JsonConvert.SerializeObject(obj, settings), Encoding.UTF8, "application/json");
+            message.Content = new StringContent(obj.ToJson(), Encoding.UTF8, "application/json");
 
             var response = await Session.RESTClient.SendAsync(message);
             if (response.IsSuccessStatusCode)

--- a/Reporting/Report.cs
+++ b/Reporting/Report.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Text;
+using EncompassREST.Json;
 
 namespace EncompassREST.Reporting
 {
@@ -57,11 +58,11 @@ namespace EncompassREST.Reporting
                 var jaAdd = ja as IDictionary<string, object>;
                 foreach (var kp in _fields)
                 {
-                    jaAdd.Add(kp.Key, loan.GetLoanValueJSONRecursive(kp.Value));
+                    jaAdd.Add(kp.Key, loan.GetLoanValueJsonRecursive(kp.Value));
                 }
                 rep.Add(loan.encompassId, ja);
             }
-            return JsonConvert.SerializeObject(report);
+            return report.ToJson();
         }
 
         [Obsolete]

--- a/Schemas.cs
+++ b/Schemas.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using EncompassREST.Exceptions;
 using EncompassREST.HelperClasses;
-using EncompassREST.JsonHelpers;
+using EncompassREST.Json;
 using Newtonsoft.Json.Linq;
 
 namespace EncompassREST

--- a/app.config
+++ b/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/packages.config
+++ b/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Added the JsonHelper class to use common serialization settings. Upgraded to Json.NET 9.0.1. Added CamelCaseNamingStrategy to automatically camelCase property names. This will allow us to use PascalCase for the generated class's properties.